### PR TITLE
Show term description on tax listing pages

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -22,7 +22,7 @@ $context[ 'title' ] = get_the_archive_title();
 if ( is_post_type_archive() ) {
   array_unshift( $templates, 'archive-' . get_post_type() . '.twig' );
 } else if ( is_category() ) {
-	array_unshift( $templates, 'archive-' . get_query_var( 'cat' ) . '.twig' );
+	array_unshift( $templates, 'archive-' . get_query_var( 'category_name' ) . '.twig' );
 } else if ( is_tag() ) {
   array_unshift( $templates, 'archive-' . get_query_var( 'tag' ) . '.twig' );
 }

--- a/archive.php
+++ b/archive.php
@@ -27,6 +27,9 @@ if ( is_post_type_archive() ) {
   array_unshift( $templates, 'archive-' . get_query_var( 'tag' ) . '.twig' );
 }
 
+$context[ 'term' ] = new Timber\Term();
+$context[ 'term' ]->desc = get_the_archive_description();
+
 $context['posts'] = new Timber\PostQuery();
 
 $loader = new \Timber\Loader( trailingslashit( get_template_directory() ) . 'templates/main-content' );

--- a/templates/main-content/archive.twig
+++ b/templates/main-content/archive.twig
@@ -5,6 +5,15 @@
 {% block subtitle %}
 {% endblock %}
 
+{% block desc %}
+  {% if term.desc %}
+    <div class="intro-text">
+      {{ term.desc }}
+    </div>
+    <hr/>
+  {% endif %}
+{% endblock %}
+
 {% for post in posts %}
   {% if option.list_page_display == 'excerpts' %}
     {% include ["partial/tease-"~post.post_type~".twig", "partial/tease.twig"] %}


### PR DESCRIPTION
- Show term description on tax listing pages
- Use category slug to search for templates, not id